### PR TITLE
聊天接口入参新增返回格式字段

### DIFF
--- a/src/main/java/com/plexpt/chatgpt/entity/chat/ChatCompletion.java
+++ b/src/main/java/com/plexpt/chatgpt/entity/chat/ChatCompletion.java
@@ -103,6 +103,12 @@ public class ChatCompletion implements Serializable {
      */
     private String user;
 
+    /**
+     * 返回格式  当前只有gpt-3.5-turbo-1106和gpt-4-1106-preview 支持json_object格式返回
+     */
+    @JsonProperty("response_format")
+    private ResponseFormat responseFormat;
+
 
     @Getter
     @AllArgsConstructor

--- a/src/main/java/com/plexpt/chatgpt/entity/chat/ResponseFormat.java
+++ b/src/main/java/com/plexpt/chatgpt/entity/chat/ResponseFormat.java
@@ -1,0 +1,31 @@
+package com.plexpt.chatgpt.entity.chat;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.*;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * @author hq
+ * @version 1.0
+ * @date 2023/12/11
+ */
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(force = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ResponseFormat {
+
+    public String type = Type.TEXT.getValue();
+
+    @Getter
+    @AllArgsConstructor
+    public enum Type {
+        JSON_OBJECT("json_object"),
+        TEXT("text");
+        private final String value;
+    }
+}


### PR DESCRIPTION
ChatCompletion类新增responseFormat 可以指定返回格式（当前只有gpt-3.5-turbo-1106和gpt-4-1106-preview 支持json_object格式返回）