### PR TITLE
fix: 代码检测时因无默认值导致报错

### DIFF
--- a/src/main/java/com/plexpt/chatgpt/entity/chat/ChatCompletion.java
+++ b/src/main/java/com/plexpt/chatgpt/entity/chat/ChatCompletion.java
@@ -88,13 +88,15 @@ public class ChatCompletion implements Serializable {
 
 
     @JsonProperty("presence_penalty")
-    private double presencePenalty;
+    @Builder.Default
+    private double presencePenalty = 0;
 
     /**
      * -2.0 ~~ 2.0
      */
     @JsonProperty("frequency_penalty")
-    private double frequencyPenalty;
+    @Builder.Default
+    private double frequencyPenalty = 0;
 
     @JsonProperty("logit_bias")
     private Map logitBias;


### PR DESCRIPTION
修复IDEA 检查代码时，因为该字段无显式的默认值导致的错误检查
![image](https://github.com/PlexPt/chatgpt-java/assets/49911488/ddaa473a-92f7-4d74-977f-577363eec508)
